### PR TITLE
magrittr required to run through the example

### DIFF
--- a/vignettes/ALA4R.Rmd
+++ b/vignettes/ALA4R.Rmd
@@ -128,7 +128,7 @@ ala_config(warn_on_empty=TRUE)
 First, check that we have some additional packages that we'll use in the examples, and install them if necessary.
 ```{r message=FALSE}
 to_install <- c("ape", "dplyr", "ggplot2", "jpeg", "maps", "mapdata",
-                "maptools", "phytools", "tidyr", "vegan")
+                "maptools", "phytools", "tidyr", "vegan", "magrittr")
 to_install <- to_install[!sapply(to_install, requireNamespace, quietly=TRUE)]
 if(length(to_install)>0)
     install.packages(to_install, repos="http://cran.us.r-project.org")
@@ -142,6 +142,7 @@ library(dplyr)
 ```{r message=FALSE}
 library(ape)
 library(phytools)
+library(magrittr)
 ```
 
 Let's say that we want to look at the taxonomic tree of penguins but we don't know what the correct scientific name is. Start by searching for it:


### PR DESCRIPTION
i just did a fresh install of Rstudio and found i needed magrittr to get the following to run:

sx$data %>% dplyr::select(name, rank, commonName)